### PR TITLE
Refactor: Removes duplicity byte send

### DIFF
--- a/lib/uart.c
+++ b/lib/uart.c
@@ -24,8 +24,7 @@ void send_message(unsigned char* message, uint8_t length) {
 }
 
 void send_char(unsigned char data) {
-	while(!(USART0.STATUS & USART_DREIF_bm));
-	USART0.TXDATAL = data;
+	send_message(&data, 1)
 }
 
 


### PR DESCRIPTION
Send_char now calls send_message with length 1 to avoid duplicated/close-similar code

Code is untested, I have no environment to build for AVR.